### PR TITLE
Plugin now works as a `pytest.mark` to generate random strings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
+  - "3.6"
 install:
   - "pip install -U pytest pytest-cov coveralls fauxfactory"
 script: "py.test -v --cov pytest_fauxfactory"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # pytest-fauxfactory
 
-[![Build Status](https://travis-ci.org/mfalesni/pytest-fauxfactory.svg?branch=master)](https://travis-ci.org/mfalesni/pytest-fauxfactory)
-[![Coverage Status](https://coveralls.io/repos/mfalesni/pytest-fauxfactory/badge.svg)](https://coveralls.io/r/mfalesni/pytest-fauxfactory)
 [![Downloads](https://pypip.in/download/pytest-fauxfactory/badge.svg?style=flat)](https://pypi.python.org/pypi/pytest-fauxfactory/)
 [![Latest version](https://pypip.in/version/pytest-fauxfactory/badge.svg?style=flat)](https://pypi.python.org/pypi/pytest-fauxfactory/)
 [![Supported Python versions](https://pypip.in/py_versions/pytest-fauxfactory/badge.svg?style=flat)](https://pypi.python.org/pypi/pytest-fauxfactory/)
@@ -9,4 +7,52 @@
 [![Format](https://pypip.in/format/pytest-fauxfactory/badge.svg?style=flat)](https://pypi.python.org/pypi/pytest-fauxfactory/)
 
 
-Library integrating fauxfactory into pytest namespace and maybe even more.
+Now you pass random data to your tests using this **Pytest** plugin for [FauxFactory](https://github.com/omaciel/fauxfactory).
+
+The easiest way to use it is to decorate your test with the `gen_string` mark and write a test that expects a `value` argument:
+
+```python
+@pytest.mark.gen_string()
+def test_generate_alpha_strings(value):
+    assert value
+```
+
+By default a single random string will be generated for your test.
+
+```shell
+test_generate_alpha_strings[:<;--{#+,&] PASSED
+```
+
+Suppose you want to generate **4** random strings (identified as **value**) for a test:
+
+```python
+@pytest.mark.gen_string(4, 'alpha')
+def test_generate_alpha_strings(value):
+    assert value.isalpha()
+```
+
+You will then have 4 tests, each with different values:
+
+```shell
+test_generate_alpha_strings[EiOKPHSXNYfv] PASSED
+test_generate_alpha_strings[BBATlPxwmHaP] PASSED
+test_generate_alpha_strings[kXIGIIXOyZyv] PASSED
+test_generate_alpha_strings[eqHxEFneSKNC] PASSED
+```
+
+Now, suppose you also want to make sure that all strings have exactly 43 characters:
+
+```python
+@pytest.mark.gen_string(4, 'alpha', length=43)
+def test_generate_alpha_strings(value):
+    assert len(value) == 43
+```
+
+You can also get random types of strings by excluding the second argument:
+
+```python
+@pytest.mark.gen_string(4)
+def test_generate_alpha_strings(value):
+    assert len(value) > 0
+```
+

--- a/conftest.py
+++ b/conftest.py
@@ -1,2 +1,18 @@
 # -*- coding: utf-8 -*-
+import pytest
+from pytest_fauxfactory import gen_string
+
+
+def pytest_generate_tests(metafunc):
+    if hasattr(metafunc.function, 'gen_string'):
+        # We should have at least the first 2 arguments to gen_string
+        args = metafunc.function.gen_string.args
+        if len(args) < 2:
+            args = (None, None)
+        items, str_type = args
+        kwargs = metafunc.function.gen_string.kwargs
+        data = gen_string(items, str_type, *args[2:], **kwargs)
+        metafunc.parametrize('value', data)
+
+
 pytest_plugins = ("pytest_fauxfactory", )  # Specify the plugin so py.test finds it on Travis

--- a/pytest_fauxfactory.py
+++ b/pytest_fauxfactory.py
@@ -1,5 +1,27 @@
 # -*- coding: utf-8 -*-
-def pytest_namespace():
-    """Inject the fauxfactory module into the pytest namespace using ``faux`` name."""
-    import fauxfactory
-    return {'faux': fauxfactory}
+import fauxfactory
+
+STRING_TYPES = (
+    'alpha',
+    'alphanumeric',
+    'cjk',
+    'html',
+    'latin1',
+    'numeric',
+    'utf8',
+    'punctuation',
+)
+
+
+def gen_string(items=None, str_type=None, *args, **kwargs):
+    '''Generate a new string type.'''
+    item = 0
+
+    if items is None:
+        items = 1
+    if str_type is None:
+        str_type = fauxfactory.gen_choice(STRING_TYPES)
+
+    while item < items:
+        yield fauxfactory.gen_string(str_type, *args, **kwargs)
+        item += 1

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,11 @@
-#!/usr/bin/env python2
 # -*- encoding: utf-8 -*-
-#   Author(s): Milan Falesnik   <milan@falesnik.net>
-#                               <mfalesni@redhat.com>
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 from setuptools import setup
 
 setup(
     name="pytest-fauxfactory",
     version="1.0",
-    author="Milan Falešník",
-    author_email="milan@falesnik.net",
+    author="Og Maciel",
+    author_email="omaciel@ogmaciel.com",
     description="Integration of fauxfactory into pytest.",
     license="GPLv3",
     keywords="pytest",

--- a/test_pytest_fauxfactory.py
+++ b/test_pytest_fauxfactory.py
@@ -2,9 +2,13 @@
 import pytest
 
 
-def test_namespace_presence():
-    pytest.faux
+@pytest.mark.gen_string()
+def test_gen_alpha_string_with_no_arguments(value):
+    '''Passing no arguments should return a random string type.'''
+    assert len(value) > 0
 
 
-def test_function_works():
-    assert len(pytest.faux.gen_alphanumeric()) > 0
+@pytest.mark.gen_string(4, 'alpha', length=12)
+def test_gen_alpha_string_with_length(value):
+    '''Generate an `alpha` string of length 12.'''
+    assert len(value) == 12


### PR DESCRIPTION
The plugin now works as a `pytest.mark` to generate random strings for your
tests.