### PR TITLE
Major refactoring applied to entire package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ package-upload: package
 		twine upload dist/*
 
 test:
-		coverage run --source pytest_fauxfactory -m py.test -v
+		coverage run --source constants,handlers,helpers,marks,pytest_fauxfactory -m py.test -v
 
 test-coverage: test
 		coverage report -m

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+"""Constants used by pytest-fauxfactory."""
+STRING_TYPES = (
+    'alpha',
+    'alphanumeric',
+    'cjk',
+    'html',
+    'latin1',
+    'numeric',
+    'utf8',
+    'punctuation',
+)

--- a/handlers.py
+++ b/handlers.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+"""Methods to handle specific pytest marks."""
+from inspect import isgenerator
+
+import pytest
+
+from constants import STRING_TYPES
+from marks import faux_callable, faux_generator, faux_string
+
+
+def callable_mark_handler(args, kwargs):
+    """"pytest faux_callable mark handler"""
+    usage_message = (
+        'usage: faux_callable(items, callable_function, *args, **kwargs)'
+    )
+
+    if len(args) < 2:
+        raise pytest.UsageError(
+            'Missing arguments: {0}'.format(usage_message)
+        )
+
+    items, callable_function = args[0:2]
+    if not isinstance(items, int):
+        raise pytest.UsageError(
+            'Mark expected an integer, got a {}: {}'.format(
+                type(items), items))
+    if items < 1:
+        raise pytest.UsageError(
+            'Mark expected an integer greater than 0, got {}'.format(
+                items))
+    if not callable(callable_function):
+        raise pytest.UsageError(
+            'Mark expected a callable function, got a {}: {}'.format(
+                type(callable_function), callable_function))
+
+    return faux_callable(items, callable_function, *args[2:], **kwargs)
+
+
+def generator_mark_handler(args, kwargs=None):
+    """"pytest faux_generator mark handler."""
+    usage_message = 'usage: faux_generator(generator)'
+
+    if len(args) == 0:
+        raise pytest.UsageError(
+            'Missing arguments, {0}'.format(usage_message)
+        )
+    for index, arg in enumerate(args):
+        if not isgenerator(arg):
+            raise pytest.UsageError(
+                'Argument with index {0} is not a generator, {1}'
+                .format(index, usage_message)
+            )
+
+    return faux_generator(*args)
+
+
+def string_mark_handler(args, kwargs):
+    """"pytest faux_string mark handler"""
+    # We should have at least the first 2 arguments to faux_string
+    if len(args) == 0:
+        args = (1, None)
+    elif len(args) == 1:
+        if isinstance(args[0], int):
+            args = (args[0], None)
+        elif isinstance(args[0], str):
+            if args[0] in STRING_TYPES:
+                args = (1, args[0])
+            else:
+                raise pytest.UsageError(
+                    'String type {} is not supported.'.format(args[0])
+                )
+    items, str_type = args[0:2]
+
+    if items < 1:
+        raise pytest.UsageError(
+            'Mark expected an integer greater than 0, got {}'.format(
+                items))
+
+    return faux_string(items, str_type, *args[2:], **kwargs)
+
+
+MARK_HANDLERS = {
+    'faux_callable': callable_mark_handler,
+    'faux_generator': generator_mark_handler,
+    'faux_string': string_mark_handler,
+}

--- a/helpers.py
+++ b/helpers.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""Provides helper methods to pytest-fauxfactory."""
+
+
+def extract_arguments(func):
+    """Extract arguments passed to a function."""
+    return func.args
+
+
+def extract_keyword_arguments(func):
+    """Extract keyword arguments passed to a function."""
+    return func.kwargs
+
+
+def get_mark_function(metafunc):
+    for key in metafunc.function.__dict__:
+        if key.lower().startswith('faux'):
+            return getattr(metafunc.function, key)

--- a/marks.py
+++ b/marks.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""FauxFactory specific marks methods."""
+from itertools import chain
+
+import fauxfactory
+
+from constants import STRING_TYPES
+
+
+def faux_callable(items, callable_func, *args, **kwargs):
+    """Generate new values from callable object."""
+    if items is None:
+        items = 1
+    for _ in range(items):
+        yield callable_func(*args, **kwargs)
+
+
+def faux_generator(*args):
+    """Generate values from generators passed as arguments."""
+    return chain.from_iterable(args)
+
+
+def faux_string(items, str_type=None, *args, **kwargs):
+    """Generate a new string type."""
+    item = 0
+
+    if str_type is None:
+        str_type = fauxfactory.gen_choice(STRING_TYPES)
+
+    while item < items:
+        yield fauxfactory.gen_string(str_type, *args, **kwargs)
+        item += 1

--- a/pytest_fauxfactory.py
+++ b/pytest_fauxfactory.py
@@ -1,135 +1,24 @@
 # -*- coding: utf-8 -*-
-"""Provides FauxFactory helper methods."""
-from inspect import isgenerator
-from itertools import chain
+"""Analyse pytest-fauxfactory marks and passes arguments and keywords to
+pytest's parametrize method."""
+from handlers import MARK_HANDLERS
 
-import fauxfactory
-import pytest
-
-STRING_TYPES = (
-    'alpha',
-    'alphanumeric',
-    'cjk',
-    'html',
-    'latin1',
-    'numeric',
-    'utf8',
-    'punctuation',
+from helpers import (
+    extract_arguments,
+    extract_keyword_arguments,
+    get_mark_function,
 )
-
-
-def faux_callable(items, callable_func, *args, **kwargs):
-    """Generate new values from callable object."""
-    if items is None:
-        items = 1
-    for _ in range(items):
-        yield callable_func(*args, **kwargs)
-
-
-def faux_generator(*args):
-    """Generate values from generators passed as arguments."""
-    return chain.from_iterable(args)
-
-
-def faux_string(items, str_type=None, *args, **kwargs):
-    """Generate a new string type."""
-    item = 0
-
-    if str_type is None:
-        str_type = fauxfactory.gen_choice(STRING_TYPES)
-
-    while item < items:
-        yield fauxfactory.gen_string(str_type, *args, **kwargs)
-        item += 1
-
-
-def _pytest_faux_callable_mark_handler(metafunc):
-    """"pytest faux_callable mark handler"""
-    args = metafunc.function.faux_callable.args
-    kwargs = metafunc.function.faux_callable.kwargs
-
-    usage_message = (
-        'usage: faux_callable(items, callable_function, *args, **kwargs)'
-    )
-
-    if len(args) < 2:
-        raise pytest.UsageError(
-            'Missing arguments: {0}'.format(usage_message)
-        )
-
-    items, callable_function = args[0:2]
-    if not isinstance(items, int):
-        raise pytest.UsageError(
-            'Mark expected an integer, got a {}: {}'.format(
-                type(items), items))
-    if items < 1:
-        raise pytest.UsageError(
-            'Mark expected an integer greater than 0, got {}'.format(
-                items))
-    if not callable(callable_function):
-        raise pytest.UsageError(
-            'Mark expected a callable function, got a {}: {}'.format(
-                type(callable_function), callable_function))
-
-    return faux_callable(items, callable_function, *args[2:], **kwargs)
-
-
-def _pytest_faux_generator_mark_handler(metafunc):
-    """"pytest faux_generator mark handler."""
-    args = metafunc.function.faux_generator.args
-    usage_message = 'usage: faux_generator(generator)'
-
-    if len(args) == 0:
-        raise pytest.UsageError(
-            'Missing arguments, {0}'.format(usage_message)
-        )
-    for index, arg in enumerate(args):
-        if not isgenerator(arg):
-            raise pytest.UsageError(
-                'Argument with index {0} is not a generator, {1}'
-                .format(index, usage_message)
-            )
-
-    return faux_generator(*args)
-
-
-def _pytest_faux_string_mark_handler(metafunc):
-    """"pytest faux_string mark handler"""
-    # We should have at least the first 2 arguments to faux_string
-    args = metafunc.function.faux_string.args
-    if len(args) == 0:
-        args = (1, None)
-    elif len(args) == 1:
-        if isinstance(args[0], int):
-            args = (args[0], None)
-        elif isinstance(args[0], str):
-            if args[0] in STRING_TYPES:
-                args = (1, args[0])
-            else:
-                raise pytest.UsageError(
-                    'String type {} is not supported.'.format(args[0])
-                )
-    items, str_type = args[0:2]
-
-    if items < 1:
-        raise pytest.UsageError(
-            'Mark expected an integer greater than 0, got {}'.format(
-                items))
-    kwargs = metafunc.function.faux_string.kwargs
-
-    return faux_string(items, str_type, *args[2:], **kwargs)
 
 
 def pytest_generate_tests(metafunc):
     """Parametrize tests using `faux_string` `faux_callable` 'faux_generator'
     marks."""
-    data = None
-    if hasattr(metafunc.function, 'faux_string'):
-        data = _pytest_faux_string_mark_handler(metafunc)
-    elif hasattr(metafunc.function, 'faux_callable'):
-        data = _pytest_faux_callable_mark_handler(metafunc)
-    elif hasattr(metafunc.function, 'faux_generator'):
-        data = _pytest_faux_generator_mark_handler(metafunc)
+    func = get_mark_function(metafunc)
+    if func:
+        args = extract_arguments(func)
+        kwargs = extract_keyword_arguments(func)
 
-    if data:
-        metafunc.parametrize('value', data)
+        data = MARK_HANDLERS[func.name](args, kwargs)
+
+        if data:
+            metafunc.parametrize('value', data)


### PR DESCRIPTION
I have split the code originally found in `pytest_fauxfactory` into several
different modules, their intentions which I hope will be clear by their names:

* constants: keep any constants used throughout code 
* handlers: functions which will be used to handle different marks
* marks: these are the mark functions themselves

The final version of `pytest_fauxfactory` is much smaller, cleaner, and
hopefully easier to maintain and understand.