### PR TITLE
Overwrite the IDs for parameters.

### DIFF
--- a/pytest_fauxfactory/helpers.py
+++ b/pytest_fauxfactory/helpers.py
@@ -2,7 +2,17 @@
 """Provides helper methods to pytest-fauxfactory."""
 
 
+def generate_ids(data, func_name):
+    """Generate IDs for parametrize method."""
+    return [
+        '{}_{}'.format(func_name, idx)
+        for idx
+        in range(len(data))
+    ]
+
+
 def get_mark_function(metafunc):
+    """Extract the name of the function being called."""
     for key in metafunc.function.__dict__:
         if key.lower().startswith('faux'):
             return getattr(metafunc.function, key)

--- a/pytest_fauxfactory/plugin.py
+++ b/pytest_fauxfactory/plugin.py
@@ -3,7 +3,7 @@
 pytest's parametrize method."""
 from pytest_fauxfactory.handlers import MARK_HANDLERS
 
-from pytest_fauxfactory.helpers import get_mark_function
+from pytest_fauxfactory.helpers import generate_ids, get_mark_function
 
 
 def pytest_generate_tests(metafunc):
@@ -18,4 +18,8 @@ def pytest_generate_tests(metafunc):
         data = MARK_HANDLERS[func.name](args, kwargs)
 
         if data:
-            metafunc.parametrize(argnames, data)
+            data = [_ for _ in data]
+            metafunc.parametrize(
+                argnames,
+                data,
+                ids=generate_ids(data, func.name))


### PR DESCRIPTION
In order to run parametrized tests in multiple threads, it is necessary to make sure that the IDs are unique for all threads. Since `fauxfactory` will generate random values, each thread being spawn will receive a different set of IDs, which does not work.

This PR will overwrite the IDs by using the name of the mark being used and appending a numeric index to it.