### PR TITLE
Handle empty list of string types for faux_string.

### DIFF
--- a/pytest_fauxfactory/marks.py
+++ b/pytest_fauxfactory/marks.py
@@ -24,7 +24,7 @@ def faux_string(items, str_type=None, *args, **kwargs):
     """Generate a new string type."""
     item = 0
 
-    if str_type is None:
+    if str_type is None or not str_type:
         str_type = fauxfactory.gen_choice(STRING_TYPES)
 
     if not isinstance(str_type, list):

--- a/pytest_fauxfactory/marks.py
+++ b/pytest_fauxfactory/marks.py
@@ -31,9 +31,12 @@ def faux_string(items, str_type=None, *args, **kwargs):
         str_type = [str_type]
     str_cycle = cycle(str_type)
 
-    if not isinstance(kwargs.get('length', None), list):
-        kwargs['length'] = [kwargs.get('length', None)]
-    length_cycle = cycle(kwargs['length'])
+    length = kwargs.get('length', None)
+    if not length:
+        length = [None]
+    if not isinstance(length, list):
+        length = [length]
+    length_cycle = cycle(length)
 
     while item < items:
         str_type = next(str_cycle)

--- a/tests/test_faux_string.py
+++ b/tests/test_faux_string.py
@@ -143,6 +143,12 @@ def test_gen_alpha_string_with_variable_length(value):
     assert len(value) == 5 or len(value) == 15
 
 
+@pytest.mark.faux_string(4, [], length=[5, 30])
+def test_gen_alpha_string_with_empty_types(value):
+    """Generate default alpha strings with length 5 and 30 characters."""
+    assert len(value) >= 5
+
+
 @pytest.mark.faux_string(4, ['alpha', 'alphanumeric'], length=[5, 30])
 def test_gen_alpha_string_with_variable_types(value):
     """Generate alpha strings with length 5, alphanumeric with length 30."""

--- a/tests/test_faux_string.py
+++ b/tests/test_faux_string.py
@@ -149,6 +149,18 @@ def test_gen_alpha_string_with_empty_types(value):
     assert len(value) >= 5
 
 
+@pytest.mark.faux_string(4, ['alpha', 'alphanumeric'], length=[])
+def test_gen_alpha_string_with_empty_length(value):
+    """Generate default alpha strings with length as empty list."""
+    assert len(value) == 10
+
+
+@pytest.mark.faux_string(4, [], length=[])
+def test_gen_alpha_string_with_empty_types_and_length(value):
+    """Generate default alpha strings with types and length as empty lists."""
+    assert len(value) >= 10
+
+
 @pytest.mark.faux_string(4, ['alpha', 'alphanumeric'], length=[5, 30])
 def test_gen_alpha_string_with_variable_types(value):
     """Generate alpha strings with length 5, alphanumeric with length 30."""


### PR DESCRIPTION
If an empty list if passed as `str_type` for `faux_string`, then choose a random type by default.