### PR TITLE
[NOT SURE IF SHOULD BE MERGED] Fix parallelized run report.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+concurrency=multiprocessing
+parallel=true
+source=pytest_fauxfactory

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,10 @@ package-upload: package
 		twine upload dist/*
 
 test:
-		coverage run --source pytest_fauxfactory -m py.test -v -n auto
+		coverage run --parallel-mode -m pytest -s -v test.py
 
 test-coverage: test
+		coverage combine
 		coverage report -m
 
 .PHONY: all docs-clean docs-html install install-dev lint package \

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,4 @@
+import coverage
+
+
+coverage.process_startup()

--- a/test.py
+++ b/test.py
@@ -1,0 +1,10 @@
+import os
+import subprocess
+
+
+os.environ['COVERAGE_PROCESS_START'] = ".coveragerc"
+
+
+def test_via_subproc():
+    proc = subprocess.Popen(["pytest", "-v", "-n", "auto"])
+    proc.wait()


### PR DESCRIPTION
```shell
make test-coverage
coverage run --parallel-mode -m pytest -s -v test.py
============================================================================================ test session starts ============================================================================================
platform darwin -- Python 3.6.3, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /Users/omaciel/.virtualenvs/pytest-fauxfactory/bin/python3.6
cachedir: .cache
rootdir: /Users/omaciel/hacking/pytest-fauxfactory, inifile:
plugins: fauxfactory-1.0.1, xdist-1.20.1, forked-0.2
collected 1 item

test.py::test_via_subproc ============================================================================================ test session starts ============================================================================================
platform darwin -- Python 3.6.3, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /Users/omaciel/.virtualenvs/pytest-fauxfactory/bin/python3.6
cachedir: .cache
rootdir: /Users/omaciel/hacking/pytest-fauxfactory, inifile:
plugins: xdist-1.20.1, forked-0.2, fauxfactory-1.0.1
[gw0] darwin Python 3.6.3 cwd: /Users/omaciel/hacking/pytest-fauxfactory
[gw1] darwin Python 3.6.3 cwd: /Users/omaciel/hacking/pytest-fauxfactory
[gw2] darwin Python 3.6.3 cwd: /Users/omaciel/hacking/pytest-fauxfactory
[gw3] darwin Python 3.6.3 cwd: /Users/omaciel/hacking/pytest-fauxfactory
[gw4] darwin Python 3.6.3 cwd: /Users/omaciel/hacking/pytest-fauxfactory
[gw5] darwin Python 3.6.3 cwd: /Users/omaciel/hacking/pytest-fauxfactory
[gw6] darwin Python 3.6.3 cwd: /Users/omaciel/hacking/pytest-fauxfactory
[gw7] darwin Python 3.6.3 cwd: /Users/omaciel/hacking/pytest-fauxfactory
[gw0] Python 3.6.3 (default, Oct  4 2017, 06:09:15)  -- [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
[gw1] Python 3.6.3 (default, Oct  4 2017, 06:09:15)  -- [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
[gw2] Python 3.6.3 (default, Oct  4 2017, 06:09:15)  -- [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
[gw3] Python 3.6.3 (default, Oct  4 2017, 06:09:15)  -- [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
[gw4] Python 3.6.3 (default, Oct  4 2017, 06:09:15)  -- [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
[gw5] Python 3.6.3 (default, Oct  4 2017, 06:09:15)  -- [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
[gw6] Python 3.6.3 (default, Oct  4 2017, 06:09:15)  -- [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
[gw7] Python 3.6.3 (default, Oct  4 2017, 06:09:15)  -- [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
gw0 [92] / gw1 [92] / gw2 [92] / gw3 [92] / gw4 [92] / gw5 [92] / gw6 [92] / gw7 [92]
scheduling tests via LoadScheduling

tests/test_custom_argument_names.py::test_multiple_argument_names_as_string[faux_callable_1]
tests/test_custom_argument_names.py::test_multiple_argument_names_as_string[faux_callable_0]
tests/test_custom_argument_names.py::test_multiple_argument_names_as_string[faux_callable_2]
tests/test_custom_argument_names.py::test_multiple_argument_names_as_string[faux_callable_3]
tests/test_custom_argument_names.py::test_multiple_argument_names_as_list[faux_callable_0]
tests/test_custom_argument_names.py::test_custom_argument_name[faux_string_0]
tests/test_faux_callable.py::test_faux_callable_with_none_items
[gw0] PASSED tests/test_custom_argument_names.py::test_multiple_argument_names_as_string[faux_callable_0]
[gw1] PASSED tests/test_custom_argument_names.py::test_multiple_argument_names_as_string[faux_callable_1]
[gw2] PASSED tests/test_custom_argument_names.py::test_multiple_argument_names_as_string[faux_callable_2]
tests/test_faux_callable.py::test_callable_mark_incorrect_items_argument
[gw6] PASSED tests/test_faux_callable.py::test_faux_callable_with_none_items
tests/test_faux_callable.py::test_callable_without_kwargs_callable_without_argument[faux_callable_0]
[gw6] PASSED tests/test_faux_callable.py::test_callable_without_kwargs_callable_without_argument[faux_callable_0]
[gw4] PASSED tests/test_custom_argument_names.py::test_multiple_argument_names_as_list[faux_callable_0]
tests/test_faux_callable.py::test_callable_mark_number_of_tests_generated
tests/test_faux_callable.py::test_callable_mark_without_callable_function
tests/test_faux_callable.py::test_callable_mark_incorrect_items_argument_type
[gw3] PASSED tests/test_custom_argument_names.py::test_multiple_argument_names_as_string[faux_callable_3]
tests/test_faux_callable.py::test_callable_mark_incorrect_callable_argument_type
tests/test_faux_callable.py::test_callable_mark_without_arguments
[gw5] PASSED tests/test_custom_argument_names.py::test_custom_argument_name[faux_string_0]
tests/test_faux_callable.py::test_callable_mark_incorrect_value
tests/test_faux_callable.py::test_callable_generate_integers[faux_callable_2]
[gw6] PASSED tests/test_faux_callable.py::test_callable_generate_integers[faux_callable_2]
tests/test_faux_callable.py::test_callable_generate_integers[faux_callable_3]
[gw6] PASSED tests/test_faux_callable.py::test_callable_generate_integers[faux_callable_3]
tests/test_faux_callable.py::test_callable_generate_from_custom_function[faux_callable_0]
[gw6] PASSED tests/test_faux_callable.py::test_callable_generate_from_custom_function[faux_callable_0]
tests/test_faux_callable.py::test_callable_generate_from_custom_function[faux_callable_1]
[gw6] PASSED tests/test_faux_callable.py::test_callable_generate_from_custom_function[faux_callable_1]
tests/test_faux_callable.py::test_callable_generate_from_custom_function[faux_callable_2]
[gw6] PASSED tests/test_faux_callable.py::test_callable_generate_from_custom_function[faux_callable_2]
tests/test_faux_callable.py::test_callable_generate_from_custom_function[faux_callable_3]
[gw6] PASSED tests/test_faux_callable.py::test_callable_generate_from_custom_function[faux_callable_3]
tests/test_faux_callable.py::test_callable_generate_from_custom_function[faux_callable_4]
[gw6] PASSED tests/test_faux_callable.py::test_callable_generate_from_custom_function[faux_callable_4]
tests/test_faux_callable.py::test_callable_generate_from_custom_function_rgb[faux_callable_0]
[gw6] PASSED tests/test_faux_callable.py::test_callable_generate_from_custom_function_rgb[faux_callable_0]
tests/test_faux_callable.py::test_callable_generate_from_custom_function_rgb[faux_callable_1]
[gw6] PASSED tests/test_faux_callable.py::test_callable_generate_from_custom_function_rgb[faux_callable_1]
tests/test_faux_callable.py::test_callable_generate_from_custom_function_rgb[faux_callable_2]
[gw6] PASSED tests/test_faux_callable.py::test_callable_generate_from_custom_function_rgb[faux_callable_2]
tests/test_faux_callable.py::test_callable_generate_from_custom_function_rgb[faux_callable_3]
[gw6] PASSED tests/test_faux_callable.py::test_callable_generate_from_custom_function_rgb[faux_callable_3]
tests/test_faux_callable.py::test_callable_generate_person[faux_callable_0]
[gw6] PASSED tests/test_faux_callable.py::test_callable_generate_person[faux_callable_0]
tests/test_faux_callable.py::test_callable_generate_person[faux_callable_1]
[gw6] PASSED tests/test_faux_callable.py::test_callable_generate_person[faux_callable_1]
tests/test_faux_callable.py::test_callable_generate_person[faux_callable_2]
[gw6] PASSED tests/test_faux_callable.py::test_callable_generate_person[faux_callable_2]
tests/test_faux_generator.py::test_generator_mark_without_arguments
[gw4] PASSED tests/test_faux_callable.py::test_callable_mark_number_of_tests_generated
tests/test_faux_callable.py::test_callable_generate_integers[faux_callable_0]
[gw4] PASSED tests/test_faux_callable.py::test_callable_generate_integers[faux_callable_0]
tests/test_faux_generator.py::test_generator_mark_combined_gens_number_of_tests_generated
[gw4] PASSED tests/test_faux_generator.py::test_generator_mark_combined_gens_number_of_tests_generated
tests/test_faux_generator.py::test_generator_alpha_strings[faux_generator_0]
[gw4] PASSED tests/test_faux_generator.py::test_generator_alpha_strings[faux_generator_0]
tests/test_faux_generator.py::test_generator_alpha_strings[faux_generator_1]
[gw4] PASSED tests/test_faux_generator.py::test_generator_alpha_strings[faux_generator_1]
tests/test_faux_generator.py::test_generator_alpha_strings[faux_generator_2]
[gw4] PASSED tests/test_faux_generator.py::test_generator_alpha_strings[faux_generator_2]
tests/test_faux_generator.py::test_generator_expression[faux_generator_0]
[gw4] PASSED tests/test_faux_generator.py::test_generator_expression[faux_generator_0]
tests/test_faux_generator.py::test_generator_expression[faux_generator_1]
[gw4] PASSED tests/test_faux_generator.py::test_generator_expression[faux_generator_1]
tests/test_faux_generator.py::test_generator_expression[faux_generator_2]
[gw4] PASSED tests/test_faux_generator.py::test_generator_expression[faux_generator_2]
tests/test_faux_generator.py::test_generator_expression[faux_generator_3]
[gw4] PASSED tests/test_faux_generator.py::test_generator_expression[faux_generator_3]
tests/test_faux_generator.py::test_generator_foo_generator[faux_generator_0]
[gw4] PASSED tests/test_faux_generator.py::test_generator_foo_generator[faux_generator_0]
tests/test_faux_generator.py::test_generator_foo_generator[faux_generator_1]
[gw4] PASSED tests/test_faux_generator.py::test_generator_foo_generator[faux_generator_1]
tests/test_faux_generator.py::test_generator_combined[faux_generator_0]
[gw4] PASSED tests/test_faux_generator.py::test_generator_combined[faux_generator_0]
tests/test_faux_generator.py::test_generator_combined[faux_generator_1]
[gw4] PASSED tests/test_faux_generator.py::test_generator_combined[faux_generator_1]
tests/test_faux_generator.py::test_generator_combined[faux_generator_2]
[gw4] PASSED tests/test_faux_generator.py::test_generator_combined[faux_generator_2]
tests/test_faux_generator.py::test_generator_combined[faux_generator_3]
[gw4] PASSED tests/test_faux_generator.py::test_generator_combined[faux_generator_3]
tests/test_faux_generator.py::test_generator_combined[faux_generator_4]
[gw4] PASSED tests/test_faux_generator.py::test_generator_combined[faux_generator_4]
tests/test_faux_generator.py::test_generator_combined[faux_generator_5]
[gw4] PASSED tests/test_faux_generator.py::test_generator_combined[faux_generator_5]
tests/test_faux_generator.py::test_generator_combined[faux_generator_6]
[gw4] PASSED tests/test_faux_generator.py::test_generator_combined[faux_generator_6]
tests/test_faux_generator.py::test_generator_combined[faux_generator_7]
[gw4] PASSED tests/test_faux_generator.py::test_generator_combined[faux_generator_7]
tests/test_faux_generator.py::test_generator_combined[faux_generator_8]
[gw4] PASSED tests/test_faux_generator.py::test_generator_combined[faux_generator_8]
tests/test_faux_string.py::test_mark_plain
[gw4] PASSED tests/test_faux_string.py::test_mark_plain
tests/test_faux_string.py::test_mark_correct_value
[gw4] PASSED tests/test_faux_string.py::test_mark_correct_value
tests/test_faux_string.py::test_mark_incorrect_value
[gw0] PASSED tests/test_faux_callable.py::test_callable_mark_without_callable_function
tests/test_faux_callable.py::test_callable_without_kwargs_callable_with_kwargs_default_values[faux_callable_0]
[gw0] PASSED tests/test_faux_callable.py::test_callable_without_kwargs_callable_with_kwargs_default_values[faux_callable_0]
tests/test_faux_string.py::test_mark_incorrect_str_type_argument
[gw2] PASSED tests/test_faux_callable.py::test_callable_mark_incorrect_items_argument
tests/test_faux_callable.py::test_callable_with_kwargs[faux_callable_0]
[gw2] PASSED tests/test_faux_callable.py::test_callable_with_kwargs[faux_callable_0]
[gw1] PASSED tests/test_faux_callable.py::test_callable_mark_incorrect_items_argument_type
[gw7] PASSED tests/test_faux_callable.py::test_callable_mark_without_arguments
tests/test_faux_string.py::test_mark_invalid_integer
tests/test_faux_callable.py::test_callable_without_kwargs_callable_with_kwargs_default_values[faux_callable_1]
tests/test_faux_callable.py::test_callable_without_kwargs_callable_without_argument[faux_callable_1]
[gw3] PASSED tests/test_faux_callable.py::test_callable_mark_incorrect_callable_argument_type
[gw1] PASSED tests/test_faux_callable.py::test_callable_without_kwargs_callable_with_kwargs_default_values[faux_callable_1]
[gw7] PASSED tests/test_faux_callable.py::test_callable_without_kwargs_callable_without_argument[faux_callable_1]
tests/test_faux_callable.py::test_callable_with_args_and_kwargs[faux_callable_0]
tests/test_faux_string.py::test_gen_alpha_string_with_limit_arguments[faux_string_0]
tests/test_faux_string.py::test_gen_alpha_string_with_length[faux_string_0]
[gw3] PASSED tests/test_faux_callable.py::test_callable_with_args_and_kwargs[faux_callable_0]
[gw1] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_limit_arguments[faux_string_0]
[gw7] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_length[faux_string_0]
tests/test_faux_string.py::test_gen_alpha_string_with_length[faux_string_3]
tests/test_faux_string.py::test_gen_alpha_string_with_length[faux_string_2]
[gw7] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_length[faux_string_3]
tests/test_faux_string.py::test_gen_alpha_string_with_length[faux_string_1]
[gw1] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_length[faux_string_2]
tests/test_faux_string.py::test_gen_alpha_string_with_validator[faux_string_0]
[gw3] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_length[faux_string_1]
[gw7] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_validator[faux_string_0]
tests/test_faux_string.py::test_gen_alpha_string_with_variable_length[faux_string_0]
[gw1] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_variable_length[faux_string_0]
tests/test_faux_string.py::test_gen_alpha_string_with_variable_length[faux_string_1]
tests/test_faux_string.py::test_gen_alpha_string_with_variable_length[faux_string_2]
[gw3] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_variable_length[faux_string_1]
[gw7] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_variable_length[faux_string_2]
tests/test_faux_string.py::test_gen_alpha_string_with_variable_length[faux_string_3]
[gw1] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_variable_length[faux_string_3]
tests/test_faux_string.py::test_gen_alpha_string_with_empty_types[faux_string_1]
tests/test_faux_string.py::test_gen_alpha_string_with_empty_types[faux_string_0]
[gw7] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_empty_types[faux_string_1]
tests/test_faux_string.py::test_gen_alpha_string_with_empty_types[faux_string_2]
[gw3] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_empty_types[faux_string_0]
[gw1] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_empty_types[faux_string_2]
tests/test_faux_string.py::test_gen_alpha_string_with_empty_length[faux_string_0]
tests/test_faux_string.py::test_gen_alpha_string_with_empty_types[faux_string_3]
tests/test_faux_string.py::test_gen_alpha_string_with_empty_length[faux_string_1]
[gw3] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_empty_length[faux_string_0]
[gw7] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_empty_types[faux_string_3]
[gw1] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_empty_length[faux_string_1]
tests/test_faux_string.py::test_gen_alpha_string_with_empty_length[faux_string_2]
tests/test_faux_string.py::test_gen_alpha_string_with_empty_types_and_length[faux_string_0]
tests/test_faux_string.py::test_gen_alpha_string_with_empty_length[faux_string_3]
[gw3] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_empty_length[faux_string_2]
[gw1] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_empty_types_and_length[faux_string_0]
[gw7] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_empty_length[faux_string_3]
tests/test_faux_string.py::test_gen_alpha_string_with_empty_types_and_length[faux_string_1]
tests/test_faux_string.py::test_gen_alpha_string_with_empty_types_and_length[faux_string_3]
tests/test_faux_string.py::test_gen_alpha_string_with_empty_types_and_length[faux_string_2]
[gw1] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_empty_types_and_length[faux_string_2]
[gw7] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_empty_types_and_length[faux_string_3]
[gw3] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_empty_types_and_length[faux_string_1]
tests/test_faux_string.py::test_gen_alpha_string_with_variable_types[faux_string_1]
[gw7] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_variable_types[faux_string_1]
[gw6] PASSED tests/test_faux_generator.py::test_generator_mark_without_arguments
tests/test_faux_generator.py::test_generator_mark_with_incorrect_argument_type
[gw5] PASSED tests/test_faux_callable.py::test_callable_mark_incorrect_value
[gw2] PASSED tests/test_faux_string.py::test_mark_invalid_integer
[gw0] PASSED tests/test_faux_string.py::test_mark_incorrect_str_type_argument
[gw6] PASSED tests/test_faux_generator.py::test_generator_mark_with_incorrect_argument_type
[gw4] PASSED tests/test_faux_string.py::test_mark_incorrect_value
tests/test_faux_string.py::test_gen_alpha_string_with_variable_types[faux_string_2]
tests/test_faux_string.py::test_mark_str_type_argument
tests/test_faux_string.py::test_gen_alpha_string_with_variable_types[faux_string_0]
tests/test_faux_string.py::test_gen_alpha_string_with_variable_types[faux_string_3]
tests/test_faux_callable.py::test_callable_generate_integers[faux_callable_1]
tests/test_faux_generator.py::test_generator_mark_number_of_tests_generated
[gw3] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_variable_types[faux_string_0]
tests/test_faux_string.py::test_gen_alpha_string_with_no_arguments[faux_string_0]
[gw1] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_variable_types[faux_string_2]
[gw7] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_variable_types[faux_string_3]
[gw5] PASSED tests/test_faux_callable.py::test_callable_generate_integers[faux_callable_1]
[gw2] PASSED tests/test_faux_string.py::test_gen_alpha_string_with_no_arguments[faux_string_0]
tests/test_faux_string.py::test_mark_incorrect_argument
[gw4] PASSED tests/test_faux_string.py::test_mark_str_type_argument
[gw6] PASSED tests/test_faux_generator.py::test_generator_mark_number_of_tests_generated
[gw0] PASSED tests/test_faux_string.py::test_mark_incorrect_argument

========================================================================================= 92 passed in 5.78 seconds =========================================================================================
PASSED

========================================================================================= 1 passed in 7.40 seconds ==========================================================================================
coverage combine
coverage report -m
Name                              Stmts   Miss  Cover   Missing
---------------------------------------------------------------
pytest_fauxfactory/__init__.py        0      0   100%
pytest_fauxfactory/constants.py       2      0   100%
pytest_fauxfactory/handlers.py       40      0   100%
pytest_fauxfactory/helpers.py         7      0   100%
pytest_fauxfactory/marks.py          29      0   100%
pytest_fauxfactory/plugin.py         13      0   100%
---------------------------------------------------------------
TOTAL                                91      0   100%
```